### PR TITLE
Avoid Interceptor instance objects

### DIFF
--- a/lib/recipient_interceptor.rb
+++ b/lib/recipient_interceptor.rb
@@ -1,28 +1,29 @@
 require 'mail'
 
 class RecipientInterceptor
-  def initialize(recipients)
-    @recipients = normalize_to_array(recipients)
-  end
 
-  def delivering_email(message)
-    message     = add_custom_headers(message)
-    message.to  = @recipients
-    message.cc  = []
-    message.bcc = []
-  end
-
-  private
-
-  def normalize_to_array(recipients)
-    if recipients.respond_to? :split
+  def self.recipients=(recipients)
+    @@recipients = if recipients.respond_to? :split
       recipients.split ','
     else
       recipients
     end
   end
 
-  def add_custom_headers(message)
+  def self.recipients
+    @@recipients ||= []
+  end
+
+  def self.delivering_email(message)
+    message     = add_custom_headers(message)
+    message.to  = recipients
+    message.cc  = []
+    message.bcc = []
+  end
+
+  private
+
+  def self.add_custom_headers(message)
     {
       'X-Intercepted-To' => message.to,
       'X-Intercepted-Cc' => message.cc,

--- a/spec/recipient_interceptor_spec.rb
+++ b/spec/recipient_interceptor_spec.rb
@@ -2,7 +2,9 @@ require File.join(File.dirname(__FILE__), '..', 'lib', 'recipient_interceptor')
 
 describe RecipientInterceptor do
   it 'overrides to/cc/bcc fields' do
-    Mail.register_interceptor RecipientInterceptor.new(recipient_string)
+    Mail.register_interceptor(RecipientInterceptor)
+
+    RecipientInterceptor.recipients = recipient_string
 
     response = deliver_mail
 
@@ -12,32 +14,32 @@ describe RecipientInterceptor do
   end
 
   it 'copies original to/cc/bcc fields to custom headers' do
-    Mail.register_interceptor RecipientInterceptor.new(recipient_string)
+    Mail.register_interceptor(RecipientInterceptor)
+
+    RecipientInterceptor.recipients = recipient_string
 
     response = deliver_mail
 
     expect(custom_header(response, 'X-Intercepted-To')).
-      to eq ['original.to@example.com', 'staging@example.com']
+      to eq 'original.to@example.com'
     expect(custom_header(response, 'X-Intercepted-Cc')).
       to eq 'original.cc@example.com'
     expect(custom_header(response, 'X-Intercepted-Bcc')).
       to eq 'original.bcc@example.com'
   end
 
-  it 'accepts an array of recipients' do
-    Mail.register_interceptor RecipientInterceptor.new(recipient_array)
+  describe '.recipients=' do
+    it 'accepts a string of recipients' do
+      RecipientInterceptor.recipients = recipient_string
 
-    response = deliver_mail
+      expect(RecipientInterceptor.recipients).to eq [recipient_string]
+    end
 
-    expect(response.to).to eq recipient_array
-  end
+    it 'accepts an array of recipients' do
+      RecipientInterceptor.recipients = recipient_array
 
-  it 'accepts a string of recipients' do
-    Mail.register_interceptor RecipientInterceptor.new(recipient_string)
-
-    response = deliver_mail
-
-    expect(response.to).to eq [recipient_string]
+      expect(RecipientInterceptor.recipients).to eq recipient_array
+    end
   end
 
   def recipient_string


### PR DESCRIPTION
I had some issues sending different emails with different recipients in my application, and while isolating tests I ran into the same issues. 

It seems to have to do with passing instance objects to `Mail.register_interceptor`.
_That_ might not be the best approach.

See: https://github.com/mikel/mail/blob/master/lib/mail/mail.rb#L216-L220 
and: https://github.com/mikel/mail/blob/master/spec/mail/message_spec.rb#L1538-L1569
