### PR TITLE
Setting cc and bcc fields to nil instead of []

### DIFF
--- a/lib/recipient_interceptor.rb
+++ b/lib/recipient_interceptor.rb
@@ -10,8 +10,8 @@ class RecipientInterceptor
     add_custom_headers message
     add_subject_prefix message
     message.to = @recipients
-    message.cc = []
-    message.bcc = []
+    message.cc = nil
+    message.bcc = nil
   end
 
   private
@@ -36,9 +36,7 @@ class RecipientInterceptor
       'X-Intercepted-Cc' => message.cc || [],
       'X-Intercepted-Bcc' => message.bcc || []
     }.each do |header, addresses|
-      addresses.each do |address|
-        message.header = "#{message.header}#{header}: #{address}"
-      end
+      message.header[header] = addresses
     end
   end
 end

--- a/spec/recipient_interceptor_spec.rb
+++ b/spec/recipient_interceptor_spec.rb
@@ -7,8 +7,8 @@ describe RecipientInterceptor do
     response = deliver_mail
 
     expect(response.to).to eq [recipient_string]
-    expect(response.cc).to eq []
-    expect(response.bcc).to eq []
+    expect(response.cc).to eq nil
+    expect(response.bcc).to eq nil
   end
 
   it 'copies original to/cc/bcc fields to custom headers' do


### PR DESCRIPTION
This was causing a problem with a certain ActionMailer proivder
(Mailgun/Railgun).

This should also be the more canonical approach to unsetting these
fields as by default they are `nil`.

Setting the Mail::Message's header differently was also require. The
previous approach would encode the message's headers to a string and
then append another encoded string to create the new headers. However,
the Bcc field is not encoded by default (see Mail::BccField#encoded @ 2.7.0).

Since the Bcc field is not present in the encoded version of the
headers, it is effectively deleted and set to []. Due to how setting
headers works in Mail, `message.bcc = nil` will not actually work.

By using Mail::Header[]= instead of Mail::Header= we do not nuke the Bcc
field and can properly use `message.bcc = nil` to remove it.