### PR TITLE
 Setting cc and bcc fields to nil instead of []

### DIFF
--- a/lib/recipient_interceptor.rb
+++ b/lib/recipient_interceptor.rb
@@ -10,8 +10,8 @@ class RecipientInterceptor
     add_custom_headers message
     add_subject_prefix message
     message.to = @recipients
-    message.cc = []
-    message.bcc = []
+    message.cc = nil if message.cc
+    message.bcc = nil if message.bcc
   end
 
   private
@@ -36,9 +36,7 @@ class RecipientInterceptor
       'X-Intercepted-Cc' => message.cc || [],
       'X-Intercepted-Bcc' => message.bcc || []
     }.each do |header, addresses|
-      addresses.each do |address|
-        message.header = "#{message.header}#{header}: #{address}"
-      end
+      message.header[header] = addresses
     end
   end
 end

--- a/lib/recipient_interceptor.rb
+++ b/lib/recipient_interceptor.rb
@@ -31,12 +31,8 @@ class RecipientInterceptor
   end
 
   def add_custom_headers(message)
-    {
-      'X-Intercepted-To' => message.to || [],
-      'X-Intercepted-Cc' => message.cc || [],
-      'X-Intercepted-Bcc' => message.bcc || []
-    }.each do |header, addresses|
-      message.header[header] = addresses
-    end
+    message.header['X-Intercepted-To'] = message.to || []
+    message.header['X-Intercepted-Cc' ] = message.cc || []
+    message.header['X-Intercepted-Bcc' ] = message.bcc || []
   end
 end

--- a/spec/recipient_interceptor_spec.rb
+++ b/spec/recipient_interceptor_spec.rb
@@ -1,6 +1,21 @@
 require File.join(File.dirname(__FILE__), '..', 'lib', 'recipient_interceptor')
 
 describe RecipientInterceptor do
+  let(:recipient_string) { 'staging@example.com' }
+  let(:recipient_array) { ['one@example.com', 'two@example.com'] }
+
+  before do
+    Mail.defaults do
+      delivery_method :test
+    end
+  end
+
+  after do
+    module Mail
+      @@delivery_interceptors = []
+    end
+  end
+
   it 'overrides to/cc/bcc fields' do
     Mail.register_interceptor RecipientInterceptor.new(recipient_string)
 
@@ -13,10 +28,6 @@ describe RecipientInterceptor do
 
   it 'overrides to/cc/bcc correctly even if they were already missing' do
     Mail.register_interceptor RecipientInterceptor.new(recipient_string)
-
-    Mail.defaults do
-      delivery_method :test
-    end
 
     response = Mail.deliver do
       from 'original.from@example.com'
@@ -76,19 +87,7 @@ describe RecipientInterceptor do
     expect(response.subject).to eq '[STAGING] some subject'
   end
 
-  def recipient_string
-    'staging@example.com'
-  end
-
-  def recipient_array
-    ['one@example.com', 'two@example.com']
-  end
-
   def deliver_mail
-    Mail.defaults do
-      delivery_method :test
-    end
-
     Mail.deliver do
       from 'original.from@example.com'
       to 'original.to@example.com'
@@ -105,12 +104,6 @@ describe RecipientInterceptor do
       header.map { |h| h.value.wrapped_string }
     else
       header.to_s
-    end
-  end
-
-  after do
-    module Mail
-      @@delivery_interceptors = []
     end
   end
 end

--- a/spec/recipient_interceptor_spec.rb
+++ b/spec/recipient_interceptor_spec.rb
@@ -1,9 +1,6 @@
 require File.join(File.dirname(__FILE__), '..', 'lib', 'recipient_interceptor')
 
 describe RecipientInterceptor do
-  let(:recipient_string) { 'staging@example.com' }
-  let(:recipient_array) { ['one@example.com', 'two@example.com'] }
-
   before do
     Mail.defaults do
       delivery_method :test
@@ -85,6 +82,14 @@ describe RecipientInterceptor do
     response = deliver_mail
 
     expect(response.subject).to eq '[STAGING] some subject'
+  end
+
+  def recipient_string
+    'staging@example.com'
+  end
+
+  def recipient_array
+    ['one@example.com', 'two@example.com']
   end
 
   def deliver_mail

--- a/spec/recipient_interceptor_spec.rb
+++ b/spec/recipient_interceptor_spec.rb
@@ -7,8 +7,25 @@ describe RecipientInterceptor do
     response = deliver_mail
 
     expect(response.to).to eq [recipient_string]
-    expect(response.cc).to eq []
-    expect(response.bcc).to eq []
+    expect(response.cc).to eq nil
+    expect(response.bcc).to eq nil
+  end
+
+  it 'overrides to/cc/bcc correctly even if they were already missing' do
+    Mail.register_interceptor RecipientInterceptor.new(recipient_string)
+
+    Mail.defaults do
+      delivery_method :test
+    end
+
+    response = Mail.deliver do
+      from 'original.from@example.com'
+      to 'original.to@example.com'
+    end
+
+    expect(response.to).to eq [recipient_string]
+    expect(response.cc).to eq nil
+    expect(response.bcc).to eq nil
   end
 
   it 'copies original to/cc/bcc fields to custom headers' do


### PR DESCRIPTION

Setting cc and bcc fields to nil instead of []  …
This was causing a problem with a certain ActionMailer proivder
(Mailgun/Railgun).

This should also be the more canonical approach to unsetting these
fields as by default they are `nil`.

Setting the Mail::Message's header differently was also require. The
previous approach would encode the message's headers to a string and
then append another encoded string to create the new headers. However,
the Bcc field is not encoded by default (see Mail::BccField#encoded @ 2.7.0).

Since the Bcc field is not present in the encoded version of the
headers, it is effectively deleted and set to []. Due to how setting
headers works in Mail, `message.bcc = nil` will not actually work.

By using Mail::Header[]= instead of Mail::Header= we do not nuke the Bcc
field and can properly use `message.bcc = nil` to remove it.