### PR TITLE
Disconnect Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language:
-  - ruby
-
-rvm:
-  - 1.9.3
-  - 2.0.0
-
-script:
-  - bundle exec rake spec


### PR DESCRIPTION
GitHub is undergoing a migration from GitHub Services to GitHub Apps.

Travis is undergoing a migration from travis-ci.org to travis-ci.com.

It's more work to re-connect these things than it's worth
for the volume of change in this project.

Perhaps re-connect Travis in the future when things have settled.