### PR TITLE
Improve new repo experience

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,6 @@
 source 'http://rubygems.org'
 
 gemspec
+
+gem "rake", "~> 12.0"
+gem "rspec", "~> 3.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,27 +7,32 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
-    diff-lcs (1.2.4)
+    diff-lcs (1.3)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     mini_mime (1.0.2)
     rake (12.3.3)
-    rspec (2.14.1)
-      rspec-core (~> 2.14.0)
-      rspec-expectations (~> 2.14.0)
-      rspec-mocks (~> 2.14.0)
-    rspec-core (2.14.4)
-    rspec-expectations (2.14.0)
-      diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.14.2)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.1)
+      rspec-support (~> 3.9.1)
+    rspec-expectations (3.9.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  rake
+  rake (~> 12.0)
   recipient_interceptor!
-  rspec
+  rspec (~> 3.0)
 
 BUNDLED WITH
-   1.16.1
+   2.1.2

--- a/README.md
+++ b/README.md
@@ -41,7 +41,12 @@ Mail.register_interceptor(
 ## Contributing
 
 Fork the repo.
-Run tests with `rake`.
+
+```
+bundle
+rake
+```
+
 Make a change.
 Run tests.
 Open a pull request.

--- a/recipient_interceptor.gemspec
+++ b/recipient_interceptor.gemspec
@@ -1,7 +1,5 @@
 Gem::Specification.new do |spec|
   spec.add_dependency 'mail'
-  spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rspec'
   spec.authors = ['Dan Croak']
 
   spec.description = <<-STRING
@@ -17,6 +15,5 @@ Gem::Specification.new do |spec|
   spec.name = 'recipient_interceptor'
   spec.require_paths = ['lib']
   spec.summary = 'Intercept recipients when delivering email with the Mail gem.'
-  spec.test_files = ['spec/recipient_interceptor_spec.rb']
   spec.version = '0.2.0'
 end


### PR DESCRIPTION
I'm on a new machine.
I wanted to try out recent changes.
I expected to be able to clone, then `bundle`, then `rake`.
`bundle` failed.

I compared this gem's `Gemfile` and `*.gemspec`
to `bundle gem`'s output as documented at
https://bundler.io/v2.0/guides/creating_gem.html

Based on its output,
I moved the development dependencies out of `*.gemspec`
and into `Gemfile`
and re-built `Gemfile.lock`.
`bundle` now succeeds.