### PR TITLE
Upgrade Ruby dependencies

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -6,11 +6,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Set up Ruby
         uses: actions/setup-ruby@v1
         with:
-          ruby-version: 2.7.x
+          ruby-version: 3.3.x
       - name: Test and lint
         run: |
           bundle

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.3.x
       - name: Test and lint

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.3.x
+          ruby-version: head
       - name: Test and lint
         run: |
           bundle

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 gemspec
 
-gem "rake", "~> 12.0"
-gem "rspec", "~> 3.0"
+gem "rake"
+gem "rspec"
 gem "standard"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,64 +1,96 @@
 PATH
   remote: .
   specs:
-    recipient_interceptor (0.3.0)
+    recipient_interceptor (0.3.1)
       mail
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     ast (2.4.2)
-    diff-lcs (1.3)
-    mail (2.7.1)
+    date (3.3.4)
+    diff-lcs (1.5.1)
+    json (2.7.2)
+    language_server-protocol (3.17.0.3)
+    lint_roller (1.1.0)
+    mail (2.8.1)
       mini_mime (>= 0.1.1)
-    mini_mime (1.0.2)
-    parallel (1.20.1)
-    parser (3.0.0.0)
+      net-imap
+      net-pop
+      net-smtp
+    mini_mime (1.1.5)
+    net-imap (0.4.11)
+      date
+      net-protocol
+    net-pop (0.1.2)
+      net-protocol
+    net-protocol (0.2.2)
+      timeout
+    net-smtp (0.5.0)
+      net-protocol
+    parallel (1.24.0)
+    parser (3.3.1.0)
       ast (~> 2.4.1)
-    rainbow (3.0.0)
-    rake (12.3.3)
-    regexp_parser (2.0.3)
-    rexml (3.2.5)
-    rspec (3.9.0)
-      rspec-core (~> 3.9.0)
-      rspec-expectations (~> 3.9.0)
-      rspec-mocks (~> 3.9.0)
-    rspec-core (3.9.1)
-      rspec-support (~> 3.9.1)
-    rspec-expectations (3.9.1)
+      racc
+    racc (1.8.0)
+    rainbow (3.1.1)
+    rake (13.2.1)
+    regexp_parser (2.9.2)
+    rexml (3.2.8)
+      strscan (>= 3.0.9)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.0)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
-    rspec-mocks (3.9.1)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
-    rspec-support (3.9.2)
-    rubocop (1.10.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.1)
+    rubocop (1.63.5)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
-      parser (>= 3.0.0.0)
+      parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
-      rexml
-      rubocop-ast (>= 1.2.0, < 2.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.4.1)
-      parser (>= 2.7.1.5)
-    rubocop-performance (1.9.2)
-      rubocop (>= 0.90.0, < 2.0)
-      rubocop-ast (>= 0.4.0)
-    ruby-progressbar (1.11.0)
-    standard (0.13.0)
-      rubocop (= 1.10.0)
-      rubocop-performance (= 1.9.2)
-    unicode-display_width (2.0.0)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.31.3)
+      parser (>= 3.3.1.0)
+    rubocop-performance (1.21.0)
+      rubocop (>= 1.48.1, < 2.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
+    ruby-progressbar (1.13.0)
+    standard (1.36.0)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.63.0)
+      standard-custom (~> 1.0.0)
+      standard-performance (~> 1.4)
+    standard-custom (1.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.50)
+    standard-performance (1.4.0)
+      lint_roller (~> 1.1)
+      rubocop-performance (~> 1.21.0)
+    strscan (3.1.0)
+    timeout (0.4.1)
+    unicode-display_width (2.5.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  rake (~> 12.0)
+  rake
   recipient_interceptor!
-  rspec (~> 3.0)
+  rspec
   standard
 
 BUNDLED WITH


### PR DESCRIPTION
Use TLS for Rubygems.

Upgrade rexml from 3.2.5 to 3.2.8 to address CVE-2024-35176
https://www.ruby-lang.org/en/news/2024/05/16/dos-rexml-cve-2024-35176/

Upgrade to modern GitHub Actions on CI.

Upgrade to Ruby 3.3 on CI.
