### PR TITLE
Upgrade Ruby dependencies

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -11,8 +11,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: head
-      - name: Test and lint
+      - name: Test
         run: |
           bundle
-          bundle exec rake
-          bundle exec standardrb
+          bundle exec rspec

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,4 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rake"
 gem "rspec"
-gem "standard"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,19 +7,15 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    ast (2.4.2)
-    date (3.3.4)
+    date (3.4.0)
     diff-lcs (1.5.1)
-    json (2.7.2)
-    language_server-protocol (3.17.0.3)
-    lint_roller (1.1.0)
     mail (2.8.1)
       mini_mime (>= 0.1.1)
       net-imap
       net-pop
       net-smtp
     mini_mime (1.1.5)
-    net-imap (0.4.11)
+    net-imap (0.5.1)
       date
       net-protocol
     net-pop (0.1.2)
@@ -28,70 +24,27 @@ GEM
       timeout
     net-smtp (0.5.0)
       net-protocol
-    parallel (1.24.0)
-    parser (3.3.1.0)
-      ast (~> 2.4.1)
-      racc
-    racc (1.8.0)
-    rainbow (3.1.1)
-    rake (13.2.1)
-    regexp_parser (2.9.2)
-    rexml (3.2.8)
-      strscan (>= 3.0.9)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
       rspec-mocks (~> 3.13.0)
-    rspec-core (3.13.0)
+    rspec-core (3.13.2)
       rspec-support (~> 3.13.0)
-    rspec-expectations (3.13.0)
+    rspec-expectations (3.13.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-mocks (3.13.1)
+    rspec-mocks (3.13.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.1)
-    rubocop (1.63.5)
-      json (~> 2.3)
-      language_server-protocol (>= 3.17.0)
-      parallel (~> 1.10)
-      parser (>= 3.3.0.2)
-      rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 1.8, < 3.0)
-      rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.31.1, < 2.0)
-      ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.31.3)
-      parser (>= 3.3.1.0)
-    rubocop-performance (1.21.0)
-      rubocop (>= 1.48.1, < 2.0)
-      rubocop-ast (>= 1.31.1, < 2.0)
-    ruby-progressbar (1.13.0)
-    standard (1.36.0)
-      language_server-protocol (~> 3.17.0.2)
-      lint_roller (~> 1.0)
-      rubocop (~> 1.63.0)
-      standard-custom (~> 1.0.0)
-      standard-performance (~> 1.4)
-    standard-custom (1.0.2)
-      lint_roller (~> 1.0)
-      rubocop (~> 1.50)
-    standard-performance (1.4.0)
-      lint_roller (~> 1.1)
-      rubocop-performance (~> 1.21.0)
-    strscan (3.1.0)
-    timeout (0.4.1)
-    unicode-display_width (2.5.0)
+    timeout (0.4.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  rake
   recipient_interceptor!
   rspec
-  standard
 
 BUNDLED WITH
-   2.2.11
+   2.5.23

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License
 
-Copyright (c) 2018 Dan Croak
+Copyright (c) Dan Croak
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The object passed to the proc is an instance of
 
 ## Alternatives
 
-* [Postmark's Sandbox mode](https://postmarkapp.com/developer/user-guide/sandbox-mode/server-sandbox-mode)
+- [Postmark's Sandbox mode](https://postmarkapp.com/developer/user-guide/sandbox-mode/server-sandbox-mode)
 
 ## Contributing
 
@@ -92,7 +92,7 @@ Fork the repo.
 
 ```
 bundle
-bundle exec rake
+bundle exec rspec
 ```
 
 Make a change.

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,0 @@
-require "bundler/gem_tasks"
-require "rspec/core/rake_task"
-
-RSpec::Core::RakeTask.new("spec")
-
-task default: :spec

--- a/spec/recipient_interceptor_spec.rb
+++ b/spec/recipient_interceptor_spec.rb
@@ -6,11 +6,9 @@ describe RecipientInterceptor do
       delivery_method :test
     end
 
-    # rubocop:disable Lint/ConstantDefinitionInBlock
     module Mail
       @@delivery_interceptors = []
     end
-    # rubocop:enable Lint/ConstantDefinitionInBlock
   end
 
   it "overrides to/cc/bcc fields and adds custom headers" do


### PR DESCRIPTION
Remove `rake` and `standardrb` dependencies. These have resulted in
frequent Dependabot alerts for their dependencies on libraries such
as `rexml`. Since `recipient_interceptor` is effectively in maintenance
mode (I don't use it day-to-day), reduce the maintenance burden by
removing development dependencies. We don't need to worry too much about
linting and we can run tests via `bundle exec rspec` directly, rather
than through `rake`.
